### PR TITLE
Rename all "Work Manager" to "WorkManager" in order to follow up Google's naming rules.

### DIFF
--- a/providers-libs/androidx.work.impl.WorkManagerInitializer.json
+++ b/providers-libs/androidx.work.impl.WorkManagerInitializer.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxy$BatteryChargingProxy.json
+++ b/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxy$BatteryChargingProxy.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxy$BatteryNotLowProxy.json
+++ b/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxy$BatteryNotLowProxy.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxy$NetworkStateProxy.json
+++ b/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxy$NetworkStateProxy.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxy$StorageNotLowProxy.json
+++ b/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxy$StorageNotLowProxy.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxyUpdateReceiver.json
+++ b/receivers-libs/androidx.work.impl.background.systemalarm.ConstraintProxyUpdateReceiver.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/receivers-libs/androidx.work.impl.background.systemalarm.RescheduleReceiver.json
+++ b/receivers-libs/androidx.work.impl.background.systemalarm.RescheduleReceiver.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/receivers-libs/androidx.work.impl.diagnostics.DiagnosticsReceiver.json
+++ b/receivers-libs/androidx.work.impl.diagnostics.DiagnosticsReceiver.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/receivers-libs/androidx.work.impl.utils.ForceStopRunnable$BroadcastReceiver.json
+++ b/receivers-libs/androidx.work.impl.utils.ForceStopRunnable$BroadcastReceiver.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/services-libs/androidx.work.impl.background.systemalarm.SystemAlarmService.json
+++ b/services-libs/androidx.work.impl.background.systemalarm.SystemAlarmService.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/services-libs/androidx.work.impl.background.systemjob.SystemJobService.json
+++ b/services-libs/androidx.work.impl.background.systemjob.SystemJobService.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],

--- a/services-libs/androidx.work.impl.foreground.SystemForegroundService.json
+++ b/services-libs/androidx.work.impl.foreground.SystemForegroundService.json
@@ -1,5 +1,5 @@
 {
-    "label": "Jetpack Work Manager",
+    "label": "Jetpack WorkManager",
     "team": "Google",
     "iconUrl": "",
     "contributors": ["Absinthe"],


### PR DESCRIPTION
See: https://developer.android.com/topic/libraries/architecture/workmanager