### PR TITLE
Add new Bugly libs and Close #365

### DIFF
--- a/native-libs/libBugly-idasc.so.json
+++ b/native-libs/libBugly-idasc.so.json
@@ -1,0 +1,8 @@
+{
+    "label": "Bugly",
+    "team": "Tencent",
+    "iconUrl": "",
+    "contributors": ["qhy040404", "Absinthe", "ArthurCyy"],
+    "description": "腾讯 Bugly，为移动开发者提供专业的异常上报和运营统计，帮助开发者快速发现并解决异常，同时掌握产品运营动态，及时跟进用户反馈。",
+    "relativeUrl": "https://bugly.qq.com/"
+}

--- a/native-libs/libBugly_Native.so.json
+++ b/native-libs/libBugly_Native.so.json
@@ -1,0 +1,8 @@
+{
+    "label": "Bugly",
+    "team": "Tencent",
+    "iconUrl": "",
+    "contributors": ["qhy040404", "Absinthe"],
+    "description": "腾讯 Bugly，为移动开发者提供专业的异常上报和运营统计，帮助开发者快速发现并解决异常，同时掌握产品运营动态，及时跟进用户反馈。",
+    "relativeUrl": "https://bugly.qq.com/"
+}


### PR DESCRIPTION
After updating Bugly from 4.0.4 to 4.1.9, libBugly-ext.so was renamed to libBugly_Native.so